### PR TITLE
Improve styling and grid setup

### DIFF
--- a/SDF-viewer_app001.py
+++ b/SDF-viewer_app001.py
@@ -1,73 +1,85 @@
 import streamlit as st
 import pandas as pd
+from io import BytesIO
+
 from rdkit import Chem
 from rdkit.Chem.Draw import rdMolDraw2D
 from rdkit.Chem import PandasTools
 from st_aggrid import AgGrid, GridOptionsBuilder
 from st_aggrid.shared import JsCode
+from streamlit.runtime.uploaded_file_manager import UploadedFile
 
-def set_custom_aggrid_css():
+# Central CSS block used for AgGrid styling
+AGGRID_CSS = """
+<style>
+/* Target AgGrid header cells specifically */
+.ag-header-cell-text {
+    white-space: normal !important;
+    text-align: right !important;
+    justify-content: flex-end !important;
+    line-height: 1.2 !important;
+    font-size: 14px !important;
+    word-wrap: break-word !important;
+    overflow-wrap: break-word !important;
+}
+
+.ag-header-cell {
+    padding: 4px !important;
+}
+
+/* Custom header class - backup */
+.custom-header {
+    white-space: normal !important;
+    text-align: right !important;
+    justify-content: flex-end !important;
+    line-height: 1.2 !important;
+    font-size: 14px;
+    padding: 4px;
+    word-wrap: break-word !important;
+}
+
+/* Right align ALL cell content */
+.ag-cell {
+    text-align: right !important;
+    justify-content: flex-end !important;
+}
+
+/* Right align cell content text specifically */
+.ag-cell-value {
+    text-align: right !important;
+}
+
+/* Ensure numeric columns stay right-aligned */
+.ag-cell-numeric {
+    text-align: right !important;
+}
+
+/* Ensure all cell wrappers are right aligned */
+.ag-cell-wrapper {
+    justify-content: flex-end !important;
+}
+
+/* Right align text columns too */
+.ag-cell-text {
+    text-align: right !important;
+}
+</style>
+"""
+
+def set_custom_aggrid_css() -> None:
     """Inject custom CSS for AgGrid header text wrapping and right alignment."""
-    st.markdown("""
-    <style>
-    /* Target AgGrid header cells specifically */
-    .ag-header-cell-text {
-        white-space: normal !important;
-        text-align: right !important;
-        justify-content: flex-end !important;
-        line-height: 1.2 !important;
-        font-size: 14px !important;
-        word-wrap: break-word !important;
-        overflow-wrap: break-word !important;
-    }
-    
-    .ag-header-cell {
-        padding: 4px !important;
-    }
-    
-    /* Custom header class - backup */
-    .custom-header {
-        white-space: normal !important;
-        text-align: right !important;
-        justify-content: flex-end !important;
-        line-height: 1.2 !important;
-        font-size: 14px;
-        padding: 4px;
-        word-wrap: break-word !important;
-    }
-    
-    /* Right align ALL cell content */
-    .ag-cell {
-        text-align: right !important;
-        justify-content: flex-end !important;
-    }
-    
-    /* Right align cell content text specifically */
-    .ag-cell-value {
-        text-align: right !important;
-    }
-    
-    /* Ensure numeric columns stay right-aligned */
-    .ag-cell-numeric {
-        text-align: right !important;
-    }
-    
-    /* Ensure all cell wrappers are right aligned */
-    .ag-cell-wrapper {
-        justify-content: flex-end !important;
-    }
-    
-    /* Right align text columns too */
-    .ag-cell-text {
-        text-align: right !important;
-    }
-    </style>
-    """, unsafe_allow_html=True)
+    st.markdown(AGGRID_CSS, unsafe_allow_html=True)
 
 @st.cache_data
 def mol_to_svg_str(smiles: str) -> str:
-    """Convert a SMILES string to an HTML-embeddable SVG."""
-    mol = Chem.MolFromSmiles(smiles)
+    """Convert a SMILES string to an HTML-embeddable SVG.
+
+    Returns an empty string if the SMILES cannot be parsed.
+    """
+    try:
+        mol = Chem.MolFromSmiles(smiles)
+    except Exception:
+        return ""
     if mol is None:
         return ""
     drawer = rdMolDraw2D.MolDraw2DSVG(120, 100)
@@ -84,7 +96,7 @@ def filter_dataframe(df: pd.DataFrame) -> pd.DataFrame:
         if query:
             df = df.query(query)
     except Exception as e:
-        st.error(f"Filter error: {e}")
+        st.error(f"Invalid filter expression: {e}")
     return df
 
 def prepare_dataframe(raw_df: pd.DataFrame) -> pd.DataFrame:
@@ -97,7 +109,7 @@ def prepare_dataframe(raw_df: pd.DataFrame) -> pd.DataFrame:
     df.insert(1, "Structure", df['SMILES'].apply(lambda smi: mol_to_svg_str(smi) if pd.notna(smi) else ""))
     return df
 
-def get_svg_cellrenderer():
+def get_svg_cellrenderer() -> JsCode:
     """
     JavaScript cell renderer to correctly render HTML/SVG in AgGrid cells.
     """
@@ -113,80 +125,71 @@ def get_svg_cellrenderer():
         }
     """)
 
-def build_aggrid_options(df: pd.DataFrame):
-    """
-    Build AgGrid options with explicit header wrapping and column sizing.
-    """
-    gb = GridOptionsBuilder.from_dataframe(df)
 
-    svg_cellrenderer = get_svg_cellrenderer()
-    
-    # Index column
-    gb.configure_column("Idx", 
-                       header_name="Idx", 
-                       width=60,
-                       minWidth=60,
-                       maxWidth=60,
-                       pinned='left', 
-                       resizable=False, 
-                       headerClass="custom-header",
-                       wrapHeaderText=True,
-                       cellStyle={'textAlign': 'right'})  # Right align content
-    
-    # Structure column - keep structure images left aligned for visual clarity
-    gb.configure_column("Structure", 
-                       header_name="Structure", 
-                       width=130,
-                       minWidth=130,
-                       maxWidth=130,
-                       resizable=False, 
-                       cellRenderer=svg_cellrenderer, 
-                       headerClass="custom-header",
-                       wrapHeaderText=True,
-                       cellStyle={'textAlign': 'center'})  # Center align structure images
-    
-    # All other columns - FORCE WIDTH TO 50px and right align
-    for col in df.columns:
-        if col not in ["Idx", "Structure"]:
-            gb.configure_column(col, 
-                              width=50,
-                              minWidth=50,
-                              maxWidth=200,  # Allow some expansion but start at 50
-                              flex=0,  # Disable flex sizing
-                              resizable=True, 
-                              headerClass="custom-header",
-                              wrapHeaderText=True,
-                              suppressSizeToFit=True,
-                              suppressAutoSize=True,
-                              cellStyle={'textAlign': 'right'},  # Right align content
-                              type='numericColumn')  # Use numeric type for consistent right alignment
-
-    # Configure default column properties with right alignment
-    gb.configure_default_column(
-        wrapText=True, 
-        suppressSizeToFit=True,
-        suppressAutoSize=True,
-        flex=0,  # Disable flex for all columns
-        cellStyle={'textAlign': 'right'}  # Right align all content by default
+def _configure_index_column(gb: GridOptionsBuilder) -> None:
+    """Configure the AgGrid index column."""
+    gb.configure_column(
+        "Idx",
+        header_name="Idx",
+        width=60,
+        minWidth=60,
+        maxWidth=60,
+        pinned="left",
+        resizable=False,
+        headerClass="custom-header",
+        wrapHeaderText=True,
+        cellStyle={"textAlign": "right"},
     )
-    
-    # Build grid options
-    grid_options = gb.build()
-    
-    # Set row height and header height
-    grid_options['getRowHeight'] = JsCode("function(params) { return 100; }")
-    grid_options['headerHeight'] = 80
-    
-    # CRITICAL: These settings prevent all auto-sizing
-    grid_options['suppressColumnVirtualisation'] = True
-    grid_options['suppressAutoSize'] = True
-    grid_options['suppressSizeToFit'] = True
-    grid_options['skipHeaderOnAutoSize'] = True
-    
-    # Force column definitions to override any auto-sizing AND set right alignment
-    grid_options['onGridReady'] = JsCode("""
+
+
+def _configure_structure_column(gb: GridOptionsBuilder, renderer: JsCode) -> None:
+    """Configure the structure column for SVG rendering."""
+    gb.configure_column(
+        "Structure",
+        header_name="Structure",
+        width=130,
+        minWidth=130,
+        maxWidth=130,
+        resizable=False,
+        cellRenderer=renderer,
+        headerClass="custom-header",
+        wrapHeaderText=True,
+        cellStyle={"textAlign": "center"},
+    )
+
+
+def _configure_other_columns(gb: GridOptionsBuilder, df: pd.DataFrame) -> None:
+    """Configure all remaining DataFrame columns."""
+    for col in df.columns:
+        if col in ["Idx", "Structure"]:
+            continue
+        gb.configure_column(
+            col,
+            width=50,
+            minWidth=50,
+            maxWidth=200,
+            flex=0,
+            resizable=True,
+            headerClass="custom-header",
+            wrapHeaderText=True,
+            suppressSizeToFit=True,
+            suppressAutoSize=True,
+            cellStyle={"textAlign": "right"},
+            type="numericColumn",
+        )
+
+
+def _apply_common_grid_options(grid_options: dict) -> None:
+    """Apply common grid options for consistent layout."""
+    grid_options["getRowHeight"] = JsCode("function(params) { return 100; }")
+    grid_options["headerHeight"] = 80
+    grid_options["suppressColumnVirtualisation"] = True
+    grid_options["suppressAutoSize"] = True
+    grid_options["suppressSizeToFit"] = True
+    grid_options["skipHeaderOnAutoSize"] = True
+    grid_options["onGridReady"] = JsCode(
+        """
         function(params) {
-            // Force column widths and right alignment after grid is ready
             const columnDefs = params.api.getColumnDefs();
             columnDefs.forEach(function(colDef) {
                 if (colDef.field !== 'Idx' && colDef.field !== 'Structure') {
@@ -201,8 +204,7 @@ def build_aggrid_options(df: pd.DataFrame):
                 colDef.headerClass = 'custom-header';
             });
             params.api.setColumnDefs(columnDefs);
-            
-            // Apply right alignment to all existing cells (except structure)
+
             const allCells = document.querySelectorAll('.ag-cell');
             allCells.forEach(function(cell) {
                 const colId = cell.getAttribute('col-id');
@@ -215,11 +217,31 @@ def build_aggrid_options(df: pd.DataFrame):
                 }
             });
         }
-    """)
-    
+        """
+    )
+
+def build_aggrid_options(df: pd.DataFrame) -> dict:
+    """Build AgGrid options with explicit header wrapping and column sizing."""
+    gb = GridOptionsBuilder.from_dataframe(df)
+    svg_cellrenderer = get_svg_cellrenderer()
+
+    _configure_index_column(gb)
+    _configure_structure_column(gb, svg_cellrenderer)
+    _configure_other_columns(gb, df)
+
+    gb.configure_default_column(
+        wrapText=True,
+        suppressSizeToFit=True,
+        suppressAutoSize=True,
+        flex=0,
+        cellStyle={"textAlign": "right"},
+    )
+
+    grid_options = gb.build()
+    _apply_common_grid_options(grid_options)
     return grid_options
 
-def display_aggrid_table(df: pd.DataFrame, grid_options: dict):
+def display_aggrid_table(df: pd.DataFrame, grid_options: dict) -> None:
     """
     Render the DataFrame in AgGrid, left-aligned with custom header styling.
     """
@@ -237,38 +259,54 @@ def display_aggrid_table(df: pd.DataFrame, grid_options: dict):
     )
     st.markdown("</div>", unsafe_allow_html=True)
 
-def load_data(uploaded_file):
-    """Load SDF or CSV file and return as DataFrame."""
-    file_type = uploaded_file.name.split('.')[-1].lower()
-    if file_type == 'sdf':
-        df = PandasTools.LoadSDF(uploaded_file, smilesName='SMILES', includeFingerprints=False)
-    elif file_type == 'csv':
-        df = pd.read_csv(uploaded_file)
-        if 'SMILES' not in df.columns:
-            st.error("CSV must contain a 'SMILES' column.")
-            st.stop()
-    else:
-        st.error("Unsupported file type.")
-        st.stop()
+@st.cache_data
+def load_data(file_bytes: bytes, file_name: str) -> pd.DataFrame:
+    """Load SDF or CSV data from the uploaded file bytes."""
+    file_type = file_name.split('.')[-1].lower()
+    try:
+        if file_type == 'sdf':
+            df = PandasTools.LoadSDF(
+                BytesIO(file_bytes), smilesName='SMILES', includeFingerprints=False
+            )
+        elif file_type == 'csv':
+            df = pd.read_csv(BytesIO(file_bytes))
+        else:
+            raise ValueError("Unsupported file type.")
+    except Exception as e:
+        raise RuntimeError(f"Failed to load file: {e}") from e
+
     if 'SMILES' not in df.columns:
-        st.error("No SMILES found.")
-        st.stop()
+        raise ValueError("No SMILES column found.")
+
     return df
 
-def main():
+def setup_page() -> None:
+    """Configure the Streamlit page and apply custom styling."""
     st.set_page_config(layout="wide")
     st.title("SDF/CSV Molecule Viewer with AgGrid")
     set_custom_aggrid_css()
 
-    uploaded_file = st.file_uploader("Upload a file (.sdf or .csv)", type=['sdf', 'csv'])
 
+def process_uploaded_file(uploaded_file: UploadedFile) -> None:
+    """Load, filter and display the uploaded file."""
+    try:
+        raw_df = load_data(uploaded_file.getvalue(), uploaded_file.name)
+    except Exception as e:
+        st.error(str(e))
+        return
+
+    df = prepare_dataframe(raw_df)
+    df_filtered = filter_dataframe(df)
+    grid_options = build_aggrid_options(df_filtered)
+    st.subheader("Filtered Data with Molecule Images")
+    display_aggrid_table(df_filtered, grid_options)
+
+
+def main() -> None:
+    setup_page()
+    uploaded_file = st.file_uploader("Upload a file (.sdf or .csv)", type=['sdf', 'csv'])
     if uploaded_file:
-        raw_df = load_data(uploaded_file)
-        df = prepare_dataframe(raw_df)
-        df_filtered = filter_dataframe(df)
-        grid_options = build_aggrid_options(df_filtered)
-        st.subheader("Filtered Data with Molecule Images")
-        display_aggrid_table(df_filtered, grid_options)
+        process_uploaded_file(uploaded_file)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- centralize AgGrid CSS into module constant
- add robust SMILES parsing and filter error message
- split AgGrid column setup into helper functions
- keep page setup and main logic separate

## Testing
- `python -m py_compile SDF-viewer_app001.py`


------
https://chatgpt.com/codex/tasks/task_e_684ecd98669883329e7c3bdee2e309f5