### PR TITLE
Add README and requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# SDF Viewer Streamlit App
+
+This repository contains a Streamlit application for viewing and filtering molecules stored in SDF or CSV files. Molecules are displayed alongside their properties using `st_aggrid` for an interactive table.
+
+## Prerequisites
+
+- Python 3.8 or later
+- The Python packages listed in [`requirements.txt`](requirements.txt)
+
+RDKit can be installed via the `rdkit-pypi` package or from conda using `rdkit`.
+
+## Installation
+
+1. Create a virtual environment (optional but recommended):
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+2. Install the dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+## Running the App
+
+Run the Streamlit application with:
+
+```bash
+streamlit run SDF-viewer_app001.py
+```
+
+The web interface will open in your browser. Upload an `.sdf` or `.csv` file containing a `SMILES` column to explore and filter your molecules.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+streamlit
+pandas
+rdkit-pypi
+st_aggrid


### PR DESCRIPTION
## Summary
- document prerequisites and install instructions in README
- list packages required to run the Streamlit app

## Testing
- `python -m py_compile SDF-viewer_app001.py`


------
https://chatgpt.com/codex/tasks/task_e_684ed914bb348332bd7af537c5050132